### PR TITLE
deps: use reqwest/hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ categories = [
 
 [dependencies]
 paste = "1.0.0"
-reqwest = ">=0.10.0,<0.12.0"
+reqwest = { version = ">=0.10.0,<0.12.0", default-features = false, features = [
+    "hyper-rustls",
+] }
 serde = "1.0.69"
 serde_json = "1.0.0"
 thiserror = "1.0.0"


### PR DESCRIPTION
This prevents enabling openssl for downstream users of this crate. Rustls doesn't require dynamic libraries on the host, and is more portable.